### PR TITLE
Change display order of select user and select match

### DIFF
--- a/app/templates/main/share.html
+++ b/app/templates/main/share.html
@@ -13,20 +13,6 @@
         <label class="form-check-label" for="togglePublic">Make Public</label>
       </div>
 
-      <!-- Private sharing user -->
-      <div class="mb-3" id="privateUsersSection">
-        <label class="form-label">Select Users to Share With:</label>
-        <div class="d-flex gap-2">
-          <select id="shareUsers" class="form-select" multiple style="width: 100%; max-width: 400px;"></select>
-          <div class="d-flex flex-column gap-1">
-            <button class="btn btn-sm btn-outline-secondary" id="clearUsers" type="button">Clear</button>
-          </div>
-        </div>
-        <div class="form-text text-muted mt-1">
-          You cannot share with yourself or users you've already shared this match with.
-        </div>
-      </div>
-
       <!-- List of matches -->
       <div class="table-responsive mt-4">
         <table class="table table-hover">
@@ -52,6 +38,20 @@
             {% endfor %}
           </tbody>
         </table>
+      </div>
+
+      <!-- Private sharing user -->
+      <div class="mb-3" id="privateUsersSection">
+        <label class="form-label">Select Users to Share With:</label>
+        <div class="d-flex gap-2">
+          <select id="shareUsers" class="form-select" multiple style="width: 100%; max-width: 400px;"></select>
+          <div class="d-flex flex-column gap-1">
+            <button class="btn btn-sm btn-outline-secondary" id="clearUsers" type="button">Clear</button>
+          </div>
+        </div>
+        <div class="form-text text-muted mt-1">
+          You cannot share with yourself or users you've already shared this match with.
+        </div>
       </div>
 
       <button id="btnShare" class="btn btn-primary mt-3">Share Selected</button>


### PR DESCRIPTION
Change display order of select user and select match to fix the issue that when selecting match after selecting user, selected users will be cleared.

Before:
![first](https://github.com/user-attachments/assets/03c1844f-3fce-4c00-bdc3-6596560927dc)

After:
![after](https://github.com/user-attachments/assets/a747dab9-bde4-4254-b61f-57b55225104d)
